### PR TITLE
Support empty bindings and multiple body expressions in let[*]-values+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # compiled modules
 compiled/
 
+# docs
+doc/
+
 # common backups, autosaves, lock files, OS meta-files
 *~
 \#*
@@ -8,4 +11,3 @@ compiled/
 .DS_Store
 *.bak
 TAGS
-

--- a/main.rkt
+++ b/main.rkt
@@ -31,7 +31,7 @@
   (make-keyword-procedure
    (lambda (kws kw-args . rest)
      (apply values value+-code kws kw-args rest))
-   values))
+   (procedure-rename values 'values+)))
 
 ;; These macros are obvious
 (define-syntax-rule (let-values+/one ([formals expr]) body0 body1 ...)

--- a/main.rkt
+++ b/main.rkt
@@ -3,8 +3,7 @@
                      syntax/parse
                      syntax/stx)
          racket/contract/base
-         racket/contract/combinator
-         racket/match)
+         racket/contract/combinator)
 
 (provide values+
          call-with-values+
@@ -242,7 +241,8 @@
   (define (stress* fs)
     (define ts
       (for/list ([l*f (in-list fs)])
-        (match-define (cons l f) l*f)
+        (define l (car l*f))
+        (define f (cdr l*f))
         (when #f
           (for ([i (in-range 3)])
             (collect-garbage)))
@@ -260,7 +260,8 @@
         y
         (/ x y)))
     (for ([l*t (in-list sts)])
-      (match-define (cons l t) l*t)
+      (define l (car l*t))
+      (define t (cdr l*t))
       (printf "~a - ~a - ~a\n"
               (real->decimal-string
                (/* t (cdar sts)))

--- a/main.rkt
+++ b/main.rkt
@@ -1,11 +1,9 @@
 #lang racket/base
 (require (for-syntax racket/base
                      syntax/parse
-                     syntax/stx
-                     racket/list)
+                     syntax/stx)
          racket/contract/base
          racket/contract/combinator
-         racket/list
          racket/match)
 
 (provide values+
@@ -60,8 +58,8 @@
   (syntax-parse stx
     [()
      (values #'()
-             empty
-             empty)]
+             null
+             null)]
     [rest:id
      (with-syntax ([(tmp-rest) (generate-temporaries #'(rest))])
        (values #'tmp-rest
@@ -253,7 +251,7 @@
            (λ ()
              (for ([i (in-range N)])
                (f)))
-           empty))
+           null))
         (cons l ct)))
     (define sts
       (sort ts < #:key cdr))
@@ -265,7 +263,7 @@
       (match-define (cons l t) l*t)
       (printf "~a - ~a - ~a\n"
               (real->decimal-string
-               (/* t (cdr (first sts))))
+               (/* t (cdar sts)))
               l
               (real->decimal-string
                t))))
@@ -375,9 +373,9 @@
          (~optional ((~or ro-e:expr
                           (~seq ro-kw:keyword ro-kw-e:expr))
                      ...)
-                    #:defaults ([(ro-e 1) empty]
-                                [(ro-kw 1) empty]
-                                [(ro-kw-e 1) empty]))
+                    #:defaults ([(ro-e 1) null]
+                                [(ro-kw 1) null]
+                                [(ro-kw-e 1) null]))
          (~optional (~seq #:rest rr-ctc:expr)
                     #:defaults ([rr-ctc #'#f]))))
      (syntax/loc stx
@@ -432,7 +430,7 @@
                           (((contract-projection m) b) a))
                         (if rr-ctcv
                           (((contract-projection rr-ctcv) b) (list-tail res (length rms)))
-                          empty)))))))
+                          null)))))))
                 (raise-blame-error b f "expected procedure")))))))]))
 
 (module+ test

--- a/main.rkt
+++ b/main.rkt
@@ -96,6 +96,12 @@
 
 (define-syntax (let-values+ stx)
   (syntax-case stx ()
+    [(_ () body0 body1 ...)
+     (syntax/loc stx
+       (let () body0 body1 ...))]
+    [(_ ([formals expr]) body0 body1 ...)
+     (syntax/loc stx
+       (let-values+/one ([formals expr]) body0 body1 ...))]
     [(_ ([formals expr] ...) body0 body1 ...)
      (with-syntax ([((temp-formals (formal-id ...) (temp-formal-id ...))
                      ...)
@@ -161,6 +167,11 @@
                       (lambda x x))
    =>
    (list 7)
+
+   (let-values+ ()
+                (list 7 2))
+   =>
+   (list 7 2)
 
    (let-values+ ([(x) 8]
                  [(y) 2])

--- a/values+.scrbl
+++ b/values+.scrbl
@@ -37,10 +37,10 @@ arguments, then it can also receive a single return value from
 
 @deftogether[(
 @defform[(define-values+ kw-formals rhs-expr)]
-@defform[(let-values+ ([kw-formals rhs-expr]) body ...+)]
-@defform[(let*-values+ ([kw-formals rhs-expr]) body ...+)]
+@defform[(let-values+ ([kw-formals rhs-expr] ...) body ...+)]
+@defform[(let*-values+ ([kw-formals rhs-expr] ...) body ...+)]
 )]{
 
-Like @racket[define], @racket[let-values], and @racket[let*-values],
+Like @racket[define-values], @racket[let-values], and @racket[let*-values],
 but supporting @racket[kw-formals] as in @racket[lambda] to receive
 optional and keyword return values from @racket[rhs-expr].}


### PR DESCRIPTION
- Allow empty binding lists `()` in `let-values+` and `let*-values+` forms
- Enable support for multiple body expressions `(body ...+)`